### PR TITLE
Rewrite interface to be much simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm install -g dathttpd
 sudo setcap cap_net_bind_service=+ep `readlink -f \`which node\``
 
 # start dathttpd
-dathttpd start
+dathttpd
 ```
 
 To daemonify the server in Debian-based systems, stop the dathttpd process and
@@ -66,28 +66,10 @@ then run:
 npm install -g add-to-systemd
 
 # create a systemd entry for dathttpd
-sudo add-to-systemd dathttpd --user $(whoami) $(which dathttpd) start
+sudo add-to-systemd dathttpd --user $(whoami) $(which dathttpd)
 
 # start the dathttpd service
 sudo systemctl start dathttpd
-```
-
-You can jump into the config with your default editor via
-
-```
-dathttpd edit
-```
-
-Then reload the server via
-
-```
-dathttpd reload
-```
-
-Or stop it with
-
-```
-dathttpd stop
 ```
 
 ## Config
@@ -149,4 +131,4 @@ If true, rather than serve the assets over HTTPS, dathttpd will serve a redirect
 
 ## Env Vars
 
-  - `CONFIG=cfg_file_path` specify an alternative path to the config than `~/.dathttpd.yml`
+  - `DATHTTPD_CONFIG=cfg_file_path` specify an alternative path to the config than `~/.dathttpd.yml`

--- a/index.js
+++ b/index.js
@@ -2,43 +2,18 @@
 
 var manager = require('./lib/manager')
 
-run(process.argv[2])
-function run (command) {
-
-  console.log(`
-dathttpd ${command} ...
-`)
-
-  try {
-    // commands
-    switch (command) {
-      case 'start':
-        // start server
-        manager.start()
-        break
-
-      case 'stop':
-        // stop server
-        manager.stop()
-        break
-
-      case 'reload':
-        // send reload signal
-        manager.reload()
-        break
-
-      case 'edit':
-        // start config editor
-        // TODO
-
-      default:
-        usage()
-    }
-  } catch (e) {
-    console.error(e)
+run()
+function run () {
+  if (process.argv[2]) {
+    return usage()
   }
+
+  // start server
+  manager.start()
 }
 
 function usage () {
-  console.log(`dathttpd {start|stop|reload|edit}`)
+  console.log(`dathttpd - starts the server
+Env Vars:
+   DATHTTPD_CONFIG=~/dathttpd.yml - location of the config file`)
 }

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,4 +1,3 @@
-const npid = require('npid')
 const os = require('os')
 const fs = require('fs')
 const path = require('path')
@@ -8,69 +7,18 @@ const server = require('./server')
 // constants
 // =
 
-const PIDFILE_PATH = path.join(os.homedir(), '.dathttpd.pid')
 const CFG_PATH = process.env.CONFIG || path.join(os.homedir(), '.dathttpd.yml')
 
 // exported api
 // =
 
 exports.start = function () {
-  // setup pidfile
-  try {
-    const pidFile = npid.create(PIDFILE_PATH)
-    pidFile.removeOnExit()
-  } catch (e) {
-    throw new Error('dathttpd is already running')
-  }
-
-  // install signal listeners
-  process.on('SIGHUP', () => {
-    console.log('Received SIGHUP. Reloading ...')
-    server.stop(() => server.start(readConfig()))
-  })
-  process.on('SIGINT', () => {
-    console.log('Received SIGINT. Closing ...')
-    process.exit(0)
-  })
-
   // read config and start the server
   server.start(readConfig())
 }
 
-exports.stop = function () {
-  try {
-    // find and sigint the server process
-    const pid = getPid()
-    process.kill(pid, 'SIGINT')
-  } catch (e) {
-    // if this failed, then there's a stale pidfile...
-    deletePidFile() // destroy it!
-  }
-}
-
-exports.reload = function () {
-  // find and sighup the server process
-  const pid = getPid()
-  process.kill(pid, 'SIGHUP')
-}
-
 // internal helpers
 // =
-
-function getPid () {
-  try {
-    return fs.readFileSync(PIDFILE_PATH, 'utf8')
-  } catch (e) {
-    throw new Error('dathttpd is not running')
-  }
-}
-
-function deletePidFile () {
-  try {
-    return fs.unlinkSync(PIDFILE_PATH, 'utf8')
-  } catch (e) {
-  }
-}
 
 function readConfig () {
   let cfgRaw

--- a/lib/server.js
+++ b/lib/server.js
@@ -84,28 +84,6 @@ exports.start = function (_cfg, cb) {
   }
 }
 
-exports.stop = function (cb) {
-  // stop the dat subprocesses
-  stopAll()
-  function stopAll () {
-    // done?
-    if (Object.keys(datProcesses).length === 0) {
-      return stopServer()
-    }
-
-    // run kill
-    for (var hostname in datProcesses) {
-      datProcesses[hostname].kill()
-    }
-    setTimeout(stopAll, 100)
-  }
-
-  function stopServer () {
-    // stop the HTTPS server
-    server.close(cb)
-  }
-}
-
 // helpers
 // =
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "greenlock-express": "^2.0.9",
     "js-yaml": "^3.7.0",
     "mkdirp": "^0.5.1",
-    "npid": "^0.4.0",
     "untildify": "^3.0.2",
     "vhost": "^3.0.2"
   }


### PR DESCRIPTION
1. Since we're instructing people to use systemd to manage the process, the builtin start|stop|restart management is superfluous. It was half-baked anyway.
2. Change the env var to DATHTTPD_CONFIG to avoid collisions.