### PR TITLE
expose metrics for prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Here's an example `~/.dathttpd.yml`:
 ports:
   http: 80
   https: 443
+  metric: 8089
 directory: ~/.dathttpd
 letsencrypt:
   email: 'bob@foo.com'
@@ -132,3 +133,11 @@ If true, rather than serve the assets over HTTPS, dathttpd will serve a redirect
 ## Env Vars
 
   - `DATHTTPD_CONFIG=cfg_file_path` specify an alternative path to the config than `~/.dathttpd.yml`
+
+## Metrics
+
+dathttpd have built-in support for [Prometheus](https://prometheus.io). The metric is exposed at `http://::8089` by default.
+
+Currently we have only one metric:
+
+* `app_https_hits{hostname}` : total https requests served since server restart.

--- a/example-config.yml
+++ b/example-config.yml
@@ -1,6 +1,7 @@
 ports:
   http: 80
   https: 443
+  metric: 8089
 directory: ~/.dathttpd
 letsencrypt:
   email: 'bob@foo.com'

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
 const server = require('./server')
+const metric = require('./metric')
 
 // constants
 // =
@@ -14,7 +15,9 @@ const CFG_PATH = process.env.CONFIG || path.join(os.homedir(), '.dathttpd.yml')
 
 exports.start = function () {
   // read config and start the server
-  server.start(readConfig())
+  var config = readConfig()
+  server.start(config)
+  metric.server(config)
 }
 
 // internal helpers

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -2,14 +2,14 @@ const prom = require('prom-client')
 const http = require('http')
 
 var metric = {
-  https_hits: new prom.Counter('app_https_hits', 'Number of https requests received', ['hostname'])
+  https_hits: new prom.Counter('app_https_hits', 'Number of https requests received', ['hostname', 'path'])
 }
 
 module.exports = {middleware, server}
 
 function middleware (site) {
   return (req, res, next) => {
-    metric.https_hits.inc({hostname: site.hostname})
+    metric.https_hits.inc({hostname: site.hostname, path: req.path})
 
     next()
   }

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,18 +1,26 @@
 const prom = require('prom-client')
 const http = require('http')
+const responseTime = require('response-time')
 
 var metric = {
-  https_hits: new prom.Counter('app_https_hits', 'Number of https requests received', ['hostname', 'path'])
+  https_hits: new prom.Counter('app_https_hits', 'Number of https requests received', ['hostname', 'path']),
+  respTime: new prom.Summary('app_https_response_time_ms', 'reponse time in ms', ['hostname', 'path'])
 }
 
-module.exports = {middleware, server}
+module.exports = {hits, respTime, server}
 
-function middleware (site) {
+function hits (site) {
   return (req, res, next) => {
     metric.https_hits.inc({hostname: site.hostname, path: req.path})
 
     next()
   }
+}
+
+function respTime (site) {
+  return responseTime(function (req, res, time) {
+    metric.respTime.labels(site.hostname, req.path).observe(time)
+  })
 }
 
 function server (config) {

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,0 +1,25 @@
+const prom = require('prom-client')
+const http = require('http')
+
+var metric = {
+  https_hits: new prom.Counter('app_https_hits', 'Number of https requests received', ['hostname'])
+}
+
+module.exports = {middleware, server}
+
+function middleware (site) {
+  return (req, res, next) => {
+    metric.https_hits.inc({hostname: site.hostname})
+
+    next()
+  }
+}
+
+function server (config) {
+  var server = http.createServer(function (req, res) {
+    res.end(prom.register.metrics())
+  })
+
+  server.listen(config.ports.metrics || 8089)
+}
+

--- a/lib/server.js
+++ b/lib/server.js
@@ -95,7 +95,8 @@ exports.start = function (_cfg, cb) {
 
 function createSiteApp (site) {
   var siteApp = express()
-  siteApp.use(metric.middleware(site))
+  siteApp.use(metric.hits(site))
+  siteApp.use(metric.respTime(site))
   if (site.datOnly) {
     siteApp.get('*', (req, res) => {
       res.redirect(`dat://${site.hostname}${req.url}`)

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ const untildify = require('untildify')
 const express = require('express')
 const vhost = require('vhost')
 const greenlockExpress = require('greenlock-express')
+const metric = require('./metric')
 
 // constants
 // =
@@ -89,6 +90,7 @@ exports.start = function (_cfg, cb) {
 
 function createSiteApp (site) {
   var siteApp = express()
+  siteApp.use(metric.middleware(site))
   if (site.datOnly) {
     siteApp.get('*', (req, res) => {
       res.redirect(`dat://${site.hostname}${req.url}`)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "js-yaml": "^3.7.0",
     "mkdirp": "^0.5.1",
     "prom-client": "^7.0.1",
+    "response-time": "^2.3.2",
     "untildify": "^3.0.2",
     "vhost": "^3.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "greenlock-express": "^2.0.9",
     "js-yaml": "^3.7.0",
     "mkdirp": "^0.5.1",
+    "prom-client": "^7.0.1",
     "untildify": "^3.0.2",
     "vhost": "^3.0.2"
   }


### PR DESCRIPTION
expose metrics for [Prometheus](https://prometheus.io) at `http://:8089`. here's an example metric:

```
# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total 1.1400000000000003
.....
LOTS OF DEFAULT METRICS
...
# HELP app_https_hits Number of https requests received
# TYPE app_https_hits counter
app_https_hits{hostname="SITE.HOSTNAME"} 29
```

Grafana also [supports](https://prometheus.io/docs/visualization/grafana/) using Prometheus as data-source. Free dashboard for everyone!

![2017-02-08 09 48 37](https://cloud.githubusercontent.com/assets/8631/22720117/f54f48d6-ede3-11e6-961c-0db9adfcdb48.png)

However, since we use external dat process. There's no way to monitor its swarm status AFAIK.

partially solved #4 