### PR TITLE
Debugging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ The port to serve the HTTPS sites. Defaults to 443. (Optional)
 
 The directory where dathttpd will store your Dat archive's files. Defaults to ~/.dathttpd. (Optional)
 
+### letsencrypt
+
+Settings for LetsEncrypt. If false or unset, HTTPS will be disabled.
+
 ### letsencrypt.email
 
 The email to send Lets Encrypt? notices to. (Required)
@@ -132,3 +136,4 @@ If true, rather than serve the assets over HTTPS, dathttpd will serve a redirect
 ## Env Vars
 
   - `DATHTTPD_CONFIG=cfg_file_path` specify an alternative path to the config than `~/.dathttpd.yml`
+  - `NODE_ENV=debug|staging|production` set to `debug` or `staging` to use the lets-encrypt testing servers.

--- a/lib/server.js
+++ b/lib/server.js
@@ -68,10 +68,9 @@ exports.start = function (_cfg, cb) {
 
   // start server
   server = greenlockExpress.create({
-    server: 'https://acme-v01.api.letsencrypt.org/directory',
+    server: (process.env.NODE_ENV === 'debug' || process.env.NODE_ENV === 'staging') ? 'staging' : 'https://acme-v01.api.letsencrypt.org/directory',
     email: cfg.letsencrypt.email,
     agreeTos: cfg.letsencrypt.agreeTos,
-    debug: (process.env.DEBUG == 1),
     approveDomains: Object.keys(cfg.sites),
     app
   }).listen(cfg.ports.http, cfg.ports.https)

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@ const path = require('path')
 const untildify = require('untildify')
 const express = require('express')
 const vhost = require('vhost')
+const http = require('http')
 const greenlockExpress = require('greenlock-express')
 
 // constants
@@ -67,13 +68,18 @@ exports.start = function (_cfg, cb) {
   cfg.ports.https = cfg.ports.https || 443
 
   // start server
-  server = greenlockExpress.create({
-    server: (process.env.NODE_ENV === 'debug' || process.env.NODE_ENV === 'staging') ? 'staging' : 'https://acme-v01.api.letsencrypt.org/directory',
-    email: cfg.letsencrypt.email,
-    agreeTos: cfg.letsencrypt.agreeTos,
-    approveDomains: Object.keys(cfg.sites),
-    app
-  }).listen(cfg.ports.http, cfg.ports.https)
+  if (cfg.letsencrypt) {
+    server = greenlockExpress.create({
+      server: (process.env.NODE_ENV === 'debug' || process.env.NODE_ENV === 'staging') ? 'staging' : 'https://acme-v01.api.letsencrypt.org/directory',
+      email: cfg.letsencrypt.email,
+      agreeTos: cfg.letsencrypt.agreeTos,
+      approveDomains: Object.keys(cfg.sites),
+      app
+    }).listen(cfg.ports.http, cfg.ports.https)
+  } else {
+    server = http.createServer(app)
+    server.listen(cfg.ports.http)
+  }
   server.on('error', err => {
     console.error('Failed to create server')
     throw err


### PR DESCRIPTION
Two updates:

 - Use the lets-encrypt staging servers if NODE_ENV is set to debug or staging
 - Use HTTP if `letsencrypt` config is falsey