### PR TITLE
Fix `os is not defined` bug

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,6 @@
 const mkdirp = require('mkdirp')
 const path = require('path')
+const os = require('os')
 const untildify = require('untildify')
 const express = require('express')
 const vhost = require('vhost')


### PR DESCRIPTION
When the the directory is not explicitly set in the config file, it runs into an `os is not defined` error, because the dependencies is missing from the requires.