### PR TITLE
Fix `cannot read property 'metrics'` bug

### DIFF
--- a/lib/metric.js
+++ b/lib/metric.js
@@ -40,6 +40,6 @@ function server (config) {
     res.end(prom.register.metrics())
   })
 
-  server.listen(config.ports.metrics || 8089)
+  server.listen(config.ports && config.ports.metrics || 8089)
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -86,8 +86,8 @@ exports.start = function (_cfg, cb) {
     })
 
     // set up ports config
-    cfg.ports.http = cfg.ports.http || 80
-    cfg.ports.https = cfg.ports.https || 443
+    cfg.ports.http = cfg.ports && cfg.ports.http || 80
+    cfg.ports.https = cfg.ports && cfg.ports.https || 443
 
     // start server
     if (cfg.letsencrypt) {


### PR DESCRIPTION
When no ports are specified in the config file, this throws a `cannot read property 'metrics' of undefined` error